### PR TITLE
refactor(smartdoc):调整文档编辑相关功能

### DIFF
--- a/server/helm-smartdoc/src/main/java/com/harbortek/helm/smartdoc/config/OperationProcessor.java
+++ b/server/helm-smartdoc/src/main/java/com/harbortek/helm/smartdoc/config/OperationProcessor.java
@@ -79,7 +79,7 @@ public class OperationProcessor {
 
                         operator.tryToSave();
                     }
-                    Thread.sleep(8 * 1000);
+                    Thread.sleep(5 * 1000);
                 } catch (Exception e) {
                     log.severe(e.getMessage());
                 }

--- a/web/src/components/smart-doc/SmartDoc.vue
+++ b/web/src/components/smart-doc/SmartDoc.vue
@@ -9,12 +9,12 @@
           @IMPORT_WORD="onImportWord" @IMPORT_REQIF="onImportReqIF" @EXPORT_REQIF="onExportReqIF"></menu-bar>
 
         <h-doc ref="docRef" class="editor-holder" :loading="docLoading" :init-value="doc" :isReadonly="readOnlyMode"
-          :holder="holder" @change="onChange" @tracker-item-focus="onBlockFocused" :extConfig="extConfig">
-          <template slot="property">
+          :holder="holder" @change="onChange" @tracker-item-focus="onBlockFocused" :extConfig="extConfig" :auto-save="this.displayMode != 'preview'">
+          <template slot="property" v-if="this.displayMode != 'preview'">
             <h-icon type="document" style="cursor: pointer" @click="() => {
-              this.propertyCollapsed = !this.propertyCollapsed;
-            }
-              " title="属性面板"></h-icon>
+      this.propertyCollapsed = !this.propertyCollapsed;
+    }
+      " title="属性面板"></h-icon>
           </template>
         </h-doc>
         <CommentBar :page-id="pageId" class="editor-comment-bar" v-if="displayMode != 'preview'"></CommentBar>
@@ -32,6 +32,14 @@
       :pageSettingTrackers="page.pageSettingTrackers"></SmartDocSettingsDialog>
     <create-tracker-item-dialog :is-show-dialog="isShowCreateTrackerItemDialog" :projectId="projectId"
       :tracker="showCreateTrackerItem" @ok="onTrackerItemSaved" @cancel="isShowCreateTrackerItemDialog = false" />
+
+    <import-word-dialog :is-show-dialog="showImportWordDialog" :projectId="projectId" :page-id="pageId"
+      @cancel="showImportWordDialog = false" @ok="onImportWordOK" />
+    <import-reqIF-dialog :is-show-dialog="showImportReqIFDialog" :projectId="projectId" :page-id="pageId"
+      @cancel="showImportReqIFDialog = false" />
+    <export-reqIF-dialog :is-show-dialog="showExportReqIFDialog" :projectId="projectId" :page-id="pageId"
+      @cancel="showExportReqIFDialog = false" />
+
   </div>
 </template>
 
@@ -43,7 +51,6 @@ import CommentBar from "./CommentBar.vue";
 import PropertyView from "./PropertyView.vue";
 import SmartDocSettingsDialog from "./Settings.vue";
 import TrackerItemSelectModal from "@/components/dialog/TrackerItemSelectModal";
-import { debounce, deepEqual } from "@/utils/util";
 import MxGraphEditor from "@/components/mxgraph";
 import UserSelectModal from "@/components/dialog/UserSelectModal";
 import RemoteApi from "./RemoteApi";
@@ -139,6 +146,7 @@ export default {
     previewDoc: {
       handler: function (value) {
         if (value) {
+          
           this.readOnlyMode = false;
           this.initEditorJS();
         }
@@ -271,14 +279,7 @@ export default {
     initEditorJSBlocks() {
       if (this.displayMode == "preview") {
         const blocks = this.previewDoc?.blocks || [];
-
-        const trackerItems = [];
-        blocks.forEach((block) => {
-          if (block.data.type == 'trackerItem') {
-            trackerItems.push(block.data.trackerItem);
-          }
-        });
-        trackerItemApi.set(this.doc.id, trackerItems);
+        this.propertyCollapsed = true;
         const newDoc = {
           id: this.previewDoc?.id || nanoid(),
           blocks,
@@ -286,6 +287,7 @@ export default {
           elements: this.previewDoc.elements || [],
           lastModifiedDate: this.previewDoc.lastModifiedDate
         }
+        console.log(newDoc);
         return Promise.resolve(newDoc);
       } else {
         return findByPageId(this.projectId, this.pageId).then((doc) => {


### PR DESCRIPTION
- 修改 OperationProcessor 中的线程休眠时间，从 8 秒调整为 5 秒
- 在 SmartDoc 组件中添加导入 Word 和 ReqIF 文件以及导出 ReqIF 文件的功能
- 优化文档预览模式下的初始化逻辑- 调整属性面板的显示逻辑，只在非预览模式下显示