### PR TITLE
fix(smartdoc): 清除导入时生成的临时编号

### DIFF
--- a/server/helm-smartdoc/src/main/java/com/harbortek/helm/smartdoc/service/impl/ReqIFImportServiceImpl.java
+++ b/server/helm-smartdoc/src/main/java/com/harbortek/helm/smartdoc/service/impl/ReqIFImportServiceImpl.java
@@ -46,6 +46,7 @@ import com.harbortek.helm.tracker.entity.block.HeaderBlockData;
 import com.harbortek.helm.tracker.entity.block.TrackerItemBlockData;
 import com.harbortek.helm.tracker.entity.smartdoc.element.parser.block.Block2Node;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.SlateNode;
+import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.trackerItem.TrackerItemSlateElement;
 import com.harbortek.helm.tracker.service.*;
 import com.harbortek.helm.tracker.vo.ProjectVo;
 import com.harbortek.helm.tracker.vo.items.TrackerItemVo;
@@ -424,6 +425,14 @@ public class ReqIFImportServiceImpl implements ReqIFImportJobService {
         List<SlateNode> elements = blocks.stream().map(block -> {
             return Block2Node.parse(block);
         }).toList();
+        for (SlateNode node : elements) {
+            if (node instanceof TrackerItemSlateElement<?>) {
+                TrackerItemSlateElement ele = (TrackerItemSlateElement) node;
+                if (ele.getTrackerItem() != null) {
+                    ele.getTrackerItem().setItemNo("");
+                }
+            }
+        }
         docService.saveBlocksAndTrackerItems(projectId, pageId, elements, links);
 
         reqIFImportJobDao.deleteJob(job.getId());

--- a/server/helm-smartdoc/src/main/java/com/harbortek/helm/smartdoc/service/impl/WordImportJobServiceImpl.java
+++ b/server/helm-smartdoc/src/main/java/com/harbortek/helm/smartdoc/service/impl/WordImportJobServiceImpl.java
@@ -41,6 +41,7 @@ import com.harbortek.helm.tracker.entity.block.*;
 import com.harbortek.helm.tracker.entity.smartdoc.element.parser.block.Block2Node;
 import com.harbortek.helm.tracker.entity.smartdoc.element.parser.block.Node2Block;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.SlateNode;
+import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.trackerItem.TrackerItemSlateElement;
 import com.harbortek.helm.tracker.service.*;
 import com.harbortek.helm.tracker.vo.ProjectVo;
 import com.harbortek.helm.tracker.vo.items.TrackerItemVo;
@@ -310,7 +311,14 @@ public class WordImportJobServiceImpl implements WordImportJobService {
         Long projectId = job.getProjectId();
         Long pageId = job.getPageId();
         List<SlateNode> blocks = SlateParser.parseArray(job.getBlocksJSON());
-
+        for (SlateNode node : blocks) {
+            if (node instanceof TrackerItemSlateElement<?>) {
+                TrackerItemSlateElement ele = (TrackerItemSlateElement) node;
+                if (ele.getTrackerItem() != null) {
+                    ele.getTrackerItem().setItemNo("");
+                }
+            }
+        }
         docService.saveBlocksAndTrackerItems(projectId, pageId, blocks);
 
         wordImportJobDao.deleteJob(job.getId());


### PR DESCRIPTION
- 在 ReqIF 导入和 Word 导入过程中，为 TrackerItemSlateElement 类型的节点清除临时编号
- 确保导入后重新保存时不会保留无效的编号