### PR TITLE
feat(tracker): 添加表格解析功能并优化文档结构

### DIFF
--- a/server/helm-smartdoc/src/main/java/com/harbortek/helm/smartdoc/api/DocApi.java
+++ b/server/helm-smartdoc/src/main/java/com/harbortek/helm/smartdoc/api/DocApi.java
@@ -16,6 +16,8 @@
 
 package com.harbortek.helm.smartdoc.api;
 
+import cn.hutool.core.bean.BeanUtil;
+import cn.hutool.core.map.MapUtil;
 import cn.hutool.json.JSONArray;
 import com.harbortek.helm.common.exception.ServiceException;
 import com.harbortek.helm.smartdoc.editor.operation.util.SlateParser;
@@ -25,7 +27,11 @@ import com.harbortek.helm.smartdoc.vo.ProjectPage4BlockVo;
 import com.harbortek.helm.tracker.entity.block.DocBlock;
 import com.harbortek.helm.tracker.entity.block.TrackerItemBlockData;
 import com.harbortek.helm.tracker.entity.smartdoc.element.parser.block.Block2Node;
+import com.harbortek.helm.tracker.entity.smartdoc.element.po.PoUtils;
+import com.harbortek.helm.tracker.entity.smartdoc.element.po.SlateElements;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.SlateNode;
+import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.SlateElement;
+import com.harbortek.helm.tracker.entity.smartdoc.element.po.style.SlateStyle;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.text.SlateText;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.paragraph.ParagraphSlateElement;
 import com.harbortek.helm.tracker.entity.project.PageSettingTracker;
@@ -53,6 +59,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -141,6 +148,8 @@ public class DocApi {
 //            docVo.getElements().add(new TitleSlateElement<>());
 //        }
         docVo.setBlocks(new ArrayList<>());
+
+        docVo.setRawElements(PoUtils.toMap(docVo.getElements()));
         return ResponseEntity.ok(docVo);
     }
 

--- a/server/helm-smartdoc/src/main/java/com/harbortek/helm/smartdoc/api/ReqIFImportJobApi.java
+++ b/server/helm-smartdoc/src/main/java/com/harbortek/helm/smartdoc/api/ReqIFImportJobApi.java
@@ -16,9 +16,11 @@
 
 package com.harbortek.helm.smartdoc.api;
 
+import cn.hutool.json.JSONArray;
 import com.harbortek.helm.smartdoc.config.SmartDocMessages;
 import com.harbortek.helm.smartdoc.service.ReqIFImportJobService;
 import com.harbortek.helm.smartdoc.vo.ReqIFImportJobVo;
+import com.harbortek.helm.tracker.entity.smartdoc.element.po.PoUtils;
 import io.swagger.v3.oas.annotations.Parameter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -39,48 +41,63 @@ public class ReqIFImportJobApi {
     SmartDocMessages smartDocMessages;
 
 
-    @Parameter(name="查找历史导入")
+    @Parameter(name = "查找历史导入")
     @RequestMapping(value = "", method = RequestMethod.GET)
-    ResponseEntity<ReqIFImportJobVo> findJob(@PathVariable Long pageId,Long projectId) {
-        ReqIFImportJobVo job=  reqIFImportJobService.findExistedJob(projectId, pageId);
+    ResponseEntity<ReqIFImportJobVo> findJob(@PathVariable Long pageId, Long projectId) {
+        ReqIFImportJobVo job = reqIFImportJobService.findExistedJob(projectId, pageId);
+        if (job != null) {
+            job.setBlocksJSON(PoUtils.toMap(new JSONArray(job.getBlocksJSON())).toString());
+        }
         return ResponseEntity.ok(job);
     }
 
 
-    @Parameter(name="初始导入")
+    @Parameter(name = "初始导入")
     @RequestMapping(value = "", method = RequestMethod.POST)
     ResponseEntity<ReqIFImportJobVo> createJob(@PathVariable Long pageId, @RequestBody ReqIFImportJobVo job) {
         job.setPageId(pageId);
         job = reqIFImportJobService.createJob(job);
+        if (job != null) {
+            job.setBlocksJSON(PoUtils.toMap(new JSONArray(job.getBlocksJSON())).toString());
+        }
         return ResponseEntity.ok(job);
     }
 
 
-    @Parameter(name="执行导入规则")
+    @Parameter(name = "执行导入规则")
     @RequestMapping(value = "", method = RequestMethod.PUT)
     ResponseEntity<ReqIFImportJobVo> updateJob(@PathVariable Long pageId, @RequestBody ReqIFImportJobVo job) {
         job = reqIFImportJobService.updateJob(job);
+        if (job != null) {
+            job.setBlocksJSON(PoUtils.toMap(new JSONArray(job.getBlocksJSON())).toString());
+        }
         return ResponseEntity.ok(job);
     }
 
-    @Parameter(name="完成导入")
+    @Parameter(name = "完成导入")
     @RequestMapping(value = "/complete", method = RequestMethod.POST)
     ResponseEntity<Void> completeJob(@PathVariable Long pageId, @RequestBody ReqIFImportJobVo job) {
         reqIFImportJobService.completeJob(job);
+        if (job != null) {
+            job.setBlocksJSON(PoUtils.toMap(new JSONArray(job.getBlocksJSON())).toString());
+        }
         return ResponseEntity.ok().build();
     }
 
-    @Parameter(name="取消导入")
+    @Parameter(name = "取消导入")
     @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
-    ResponseEntity<Void> deleteJob(@PathVariable Long pageId,@PathVariable Long id) {
+    ResponseEntity<Void> deleteJob(@PathVariable Long pageId, @PathVariable Long id) {
         reqIFImportJobService.deleteJob(id);
         return ResponseEntity.ok().build();
     }
 
-    @Parameter(name="返回上一次保存的数据")
+    @Parameter(name = "返回上一次保存的数据")
     @RequestMapping(value = "/{id}/withdraw", method = RequestMethod.GET)
-    ResponseEntity<ReqIFImportJobVo> withdrawJob(@PathVariable Long pageId,@PathVariable Long id) {
+    ResponseEntity<ReqIFImportJobVo> withdrawJob(@PathVariable Long pageId, @PathVariable Long id) {
         ReqIFImportJobVo job = reqIFImportJobService.withdrawJob(id);
+        if (job != null) {
+            job.setBlocksJSON(PoUtils.toMap(new JSONArray(job.getBlocksJSON())).toString());
+        }
         return ResponseEntity.ok(job);
     }
 }

--- a/server/helm-smartdoc/src/main/java/com/harbortek/helm/smartdoc/api/WordImportJobApi.java
+++ b/server/helm-smartdoc/src/main/java/com/harbortek/helm/smartdoc/api/WordImportJobApi.java
@@ -16,9 +16,14 @@
 
 package com.harbortek.helm.smartdoc.api;
 
+import cn.hutool.core.bean.BeanUtil;
+import cn.hutool.core.bean.copier.CopyOptions;
+import cn.hutool.json.JSONArray;
+import cn.hutool.json.JSONObject;
 import com.harbortek.helm.smartdoc.config.SmartDocMessages;
 import com.harbortek.helm.smartdoc.service.WordImportJobService;
 import com.harbortek.helm.smartdoc.vo.WordImportJobVo;
+import com.harbortek.helm.tracker.entity.smartdoc.element.po.PoUtils;
 import io.swagger.v3.oas.annotations.Parameter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -29,6 +34,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 @Controller
 @RequestMapping("/smart-doc/{pageId}/import/word/job")
@@ -41,48 +50,66 @@ public class WordImportJobApi {
     SmartDocMessages smartDocMessages;
 
 
-    @Parameter(name="查找历史导入")
+    @Parameter(name = "查找历史导入")
     @RequestMapping(value = "", method = RequestMethod.GET)
-    ResponseEntity<WordImportJobVo> findJob(@PathVariable Long pageId,Long projectId) throws IOException {
-        WordImportJobVo job=  wordImportJobService.findExistedJob(projectId,pageId);
+    ResponseEntity<WordImportJobVo> findJob(@PathVariable Long pageId, Long projectId) throws IOException {
+        WordImportJobVo job = wordImportJobService.findExistedJob(projectId, pageId);
+        if (job != null) {
+            job.setBlocksJSON(PoUtils.toMap(new JSONArray(job.getBlocksJSON())).toString());
+        }
+        //样式转换
         return ResponseEntity.ok(job);
     }
 
-
-    @Parameter(name="初始导入")
+    @Parameter(name = "初始导入")
     @RequestMapping(value = "", method = RequestMethod.POST)
     ResponseEntity<WordImportJobVo> createJob(@PathVariable Long pageId, @RequestBody WordImportJobVo job) {
         job.setPageId(pageId);
         job = wordImportJobService.createJob(job);
+        if (job != null) {
+            job.setBlocksJSON(PoUtils.toMap(new JSONArray(job.getBlocksJSON())).toString());
+        }
         return ResponseEntity.ok(job);
     }
 
 
-    @Parameter(name="执行导入规则")
+    @Parameter(name = "执行导入规则")
     @RequestMapping(value = "", method = RequestMethod.PUT)
-    ResponseEntity<WordImportJobVo> updateJob(@PathVariable Long pageId, @RequestBody WordImportJobVo job) throws IOException {
+    ResponseEntity<WordImportJobVo> updateJob(@PathVariable Long pageId, @RequestBody WordImportJobVo job) throws
+            IOException {
         job = wordImportJobService.updateJob(job);
+        if (job != null) {
+            job.setBlocksJSON(PoUtils.toMap(new JSONArray(job.getBlocksJSON())).toString());
+        }
         return ResponseEntity.ok(job);
     }
 
-    @Parameter(name="完成导入")
+    @Parameter(name = "完成导入")
     @RequestMapping(value = "/complete", method = RequestMethod.POST)
-    ResponseEntity<Void> completeJob(@PathVariable Long pageId, @RequestBody WordImportJobVo job) throws IOException {
+    ResponseEntity<Void> completeJob(@PathVariable Long pageId, @RequestBody WordImportJobVo job) throws
+            IOException {
         wordImportJobService.completeJob(job);
+        if (job != null) {
+            job.setBlocksJSON(PoUtils.toMap(new JSONArray(job.getBlocksJSON())).toString());
+        }
         return ResponseEntity.ok().build();
     }
 
-    @Parameter(name="取消导入")
+    @Parameter(name = "取消导入")
     @RequestMapping(value = "/{id}", method = RequestMethod.DELETE)
-    ResponseEntity<Void> deleteJob(@PathVariable Long pageId,@PathVariable Long id) {
+    ResponseEntity<Void> deleteJob(@PathVariable Long pageId, @PathVariable Long id) {
         wordImportJobService.deleteJob(id);
         return ResponseEntity.ok().build();
     }
 
-    @Parameter(name="返回上一次保存的数据")
+    @Parameter(name = "返回上一次保存的数据")
     @RequestMapping(value = "/{id}/withdraw", method = RequestMethod.GET)
-    ResponseEntity<WordImportJobVo> withdrawJob(@PathVariable Long pageId,@PathVariable Long id) throws IOException {
+    ResponseEntity<WordImportJobVo> withdrawJob(@PathVariable Long pageId, @PathVariable Long id) throws
+            IOException {
         WordImportJobVo job = wordImportJobService.withdrawJob(id);
+        if (job != null) {
+            job.setBlocksJSON(PoUtils.toMap(new JSONArray(job.getBlocksJSON())).toString());
+        }
         return ResponseEntity.ok(job);
     }
 }

--- a/server/helm-smartdoc/src/main/java/com/harbortek/helm/smartdoc/editor/operation/util/SlateParser.java
+++ b/server/helm-smartdoc/src/main/java/com/harbortek/helm/smartdoc/editor/operation/util/SlateParser.java
@@ -27,6 +27,7 @@ import com.harbortek.helm.tracker.entity.smartdoc.element.po.SlateElements;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.SlateNode;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.*;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.header.*;
+import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.image.ImageSlateElement;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.list.ListSlateElement;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.paragraph.ParagraphSlateElement;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.table.TableSlateElement;
@@ -37,7 +38,6 @@ import com.harbortek.helm.tracker.entity.smartdoc.element.po.text.SlateText;
 import com.harbortek.helm.tracker.vo.items.TrackerItemVo;
 import com.harbortek.helm.util.JsonUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.BeanUtils;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -70,7 +70,7 @@ public class SlateParser {
 
     public static SlateNode parseOne(JSONObject obj) throws IOException {
         String type = obj.getStr("type");
-        List<SlateStyle> styles = parseStyles(obj);
+        List<StyleedStyle> styles = parseStyles(obj);
         SlateNode node = null;
         if (SlateElements.ATTACHMENT.equals(type)) {
             node = new AttachmentSlateElement();
@@ -125,7 +125,7 @@ public class SlateParser {
                 "styles"
         ));
         if (SlateElements.TRACKER_ITEM.equals(type)) {
-            TrackerItemSlateElement item = (TrackerItemSlateElement)node;
+            TrackerItemSlateElement item = (TrackerItemSlateElement) node;
             item.setTrackerItem(JsonUtils.toObject(obj.getStr("trackerItem"), TrackerItemVo.class));
         }
         node.setStyles(styles);
@@ -136,38 +136,41 @@ public class SlateParser {
                 ((SlateElement) node).setChildren(parseedChildren);
             }
         }
+        if (node.getStyles() == null || node.getStyles().isEmpty()) {
+            node.setStyles(null);
+        }
         return node;
     }
 
-    private static List<SlateStyle> parseStyles(JSONObject item) throws IOException {
+    private static List<StyleedStyle> parseStyles(JSONObject item) throws IOException {
 
         String textAlign = item.getStr("textAlign");
 
-        List<SlateStyle> styles = new ArrayList<>();
+        List<StyleedStyle> styles = new ArrayList<>();
         //justify包装
-        if (StringUtils.isNotEmpty(textAlign)) {
-            JustifyStyle justifyStyle = JustifyStyle.builder().textAlign(textAlign).build();
-            styles.add(justifyStyle);
-        }
-        //indent包装
-        String indent = item.getStr("indent");
-        if (StringUtils.isNotEmpty(indent)) {
-            IndentStyle indentStyle = IndentStyle.builder().indent(indent).build();
-            styles.add(indentStyle);
-        }
-        //lineHeight包装
-        String lineHeight = item.getStr("lineHeight");
-        if (StringUtils.isNotEmpty(lineHeight)) {
-            LineHeightStyle lineHeightElement = LineHeightStyle.builder().lineHeight(lineHeight).build();
-            styles.add(lineHeightElement);
-        }
+//        if (StringUtils.isNotEmpty(textAlign)) {
+//            JustifyStyle justifyStyle = JustifyStyle.builder().textAlign(textAlign).build();
+//            styles.add(justifyStyle);
+//        }
+//        //indent包装
+//        String indent = item.getStr("indent");
+//        if (StringUtils.isNotEmpty(indent)) {
+//            IndentStyle indentStyle = IndentStyle.builder().indent(indent).build();
+//            styles.add(indentStyle);
+//        }
+//        //lineHeight包装
+//        String lineHeight = item.getStr("lineHeight");
+//        if (StringUtils.isNotEmpty(lineHeight)) {
+//            LineHeightStyle lineHeightElement = LineHeightStyle.builder().lineHeight(lineHeight).build();
+//            styles.add(lineHeightElement);
+//        }
         //color包装
-        String color = item.getStr("color");
-        String bgColor = item.getStr("bgColor");
-        if (StringUtils.isNotEmpty(color) || StringUtils.isNotEmpty(bgColor)) {
-            ColorStyle colorStyle = ColorStyle.builder().color(color).bgColor(bgColor).build();
-            styles.add(colorStyle);
-        }
+//        String color = item.getStr("color");
+//        String bgColor = item.getStr("bgColor");
+//        if (StringUtils.isNotEmpty(color) || StringUtils.isNotEmpty(bgColor)) {
+//            ColorStyle colorStyle = ColorStyle.builder().color(color).bgColor(bgColor).build();
+//            styles.add(colorStyle);
+//        }
         //style包装
         Boolean bold = item.getBool("bold");
         Boolean code = item.getBool("code");
@@ -180,25 +183,26 @@ public class SlateParser {
                 Boolean.TRUE.equals(italic) || Boolean.TRUE.equals(through)
                 || Boolean.TRUE.equals(underline) || Boolean.TRUE.equals(sup) ||
                 Boolean.TRUE.equals(sub)) {
-            StyleedStyle styleedStyle = StyleedStyle.builder()
-                    .bold(bold)
-                    .code(code)
-                    .italic(italic)
-                    .through(through)
-                    .underline(underline)
-                    .sup(sup)
-                    .sub(sub).build();
+            StyleedStyle styleedStyle = new StyleedStyle();
+            styleedStyle.setBold(bold);
+            styleedStyle.setCode(code);
+            styleedStyle.setItalic(italic);
+            styleedStyle.setThrough(through);
+            styleedStyle.setUnderline(underline);
+            styleedStyle.setSub(sup);
+            styleedStyle.setSub(sub);
+
             styles.add(styleedStyle);
         }
         //fontSizeAndFamily包装
-        String fontSize = item.getStr("fontSize");
-        String fontFamily = item.getStr("fontFamily");
-        if (StringUtils.isNotEmpty(fontSize) || StringUtils.isNotEmpty(fontFamily)) {
-            FontSizeAndFamilyStyle fontSizeAndFamilyStyle = FontSizeAndFamilyStyle.builder()
-                    .fontSize(fontSize)
-                    .fontFamily(fontFamily).build();
-            styles.add(fontSizeAndFamilyStyle);
-        }
+//        String fontSize = item.getStr("fontSize");
+//        String fontFamily = item.getStr("fontFamily");
+//        if (StringUtils.isNotEmpty(fontSize) || StringUtils.isNotEmpty(fontFamily)) {
+//            FontSizeAndFamilyStyle fontSizeAndFamilyStyle = FontSizeAndFamilyStyle.builder()
+//                    .fontSize(fontSize)
+//                    .fontFamily(fontFamily).build();
+//            styles.add(fontSizeAndFamilyStyle);
+//        }
         return styles;
     }
 }

--- a/server/helm-smartdoc/src/main/java/com/harbortek/helm/smartdoc/service/impl/WordImportJobServiceImpl.java
+++ b/server/helm-smartdoc/src/main/java/com/harbortek/helm/smartdoc/service/impl/WordImportJobServiceImpl.java
@@ -16,6 +16,7 @@
 
 package com.harbortek.helm.smartdoc.service.impl;
 
+import ch.qos.logback.core.net.SyslogOutputStream;
 import cn.hutool.core.util.StrUtil;
 import cn.hutool.http.HtmlUtil;
 import com.harbortek.helm.common.exception.ServiceException;
@@ -41,7 +42,9 @@ import com.harbortek.helm.tracker.entity.block.*;
 import com.harbortek.helm.tracker.entity.smartdoc.element.parser.block.Block2Node;
 import com.harbortek.helm.tracker.entity.smartdoc.element.parser.block.Node2Block;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.SlateNode;
+import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.SlateElement;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.trackerItem.TrackerItemSlateElement;
+import com.harbortek.helm.tracker.entity.smartdoc.element.po.style.SlateStyle;
 import com.harbortek.helm.tracker.service.*;
 import com.harbortek.helm.tracker.vo.ProjectVo;
 import com.harbortek.helm.tracker.vo.items.TrackerItemVo;
@@ -190,6 +193,8 @@ public class WordImportJobServiceImpl implements WordImportJobService {
                         ParagraphBlockData data = new ParagraphBlockData();
                         if (element.is("ul,ol")) {
                             data.setText(element.outerHtml());
+                        } else if (element.is("table")) {
+                            data.setText(element.outerHtml());
                         } else {
                             data.setText(element.html());
                         }
@@ -319,10 +324,25 @@ public class WordImportJobServiceImpl implements WordImportJobService {
                 }
             }
         }
+//        toBlock(blocks);
         docService.saveBlocksAndTrackerItems(projectId, pageId, blocks);
 
         wordImportJobDao.deleteJob(job.getId());
     }
+
+//    private void toBlock(List<SlateNode> nodes) {
+//        for (SlateNode node : nodes) {
+//            if (node.getStyles() != null) {
+//                for (SlateStyle style : node.getStyles()) {
+//                    System.out.println(style.getClass().getName());
+//                }
+//            }
+//            if (node instanceof SlateElement<?>) {
+//                SlateElement elem = (SlateElement) node;
+//                toBlock(elem.getChildren());
+//            }
+//        }
+//    }
 
     @Override
     public void deleteJob(Long id) {

--- a/server/helm-smartdoc/src/main/java/org/zwobble/mammoth/internal/conversion/DocumentToHtml.java
+++ b/server/helm-smartdoc/src/main/java/org/zwobble/mammoth/internal/conversion/DocumentToHtml.java
@@ -146,7 +146,6 @@ public class DocumentToHtml {
     }
 
     private List<HtmlNode> convertToHtml(List<DocumentElement> elements, Context context) {
-        System.out.println("convertToHtml: " + elements);
         return eagerFlatMap(
                 elements,
                 element -> convertToHtml(element, context)

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/parser/block/Block2Node.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/parser/block/Block2Node.java
@@ -16,6 +16,7 @@
 
 package com.harbortek.helm.tracker.entity.smartdoc.element.parser.block;
 
+import cn.hutool.core.util.NumberUtil;
 import cn.hutool.http.HtmlUtil;
 import com.harbortek.helm.common.vo.IdNameReference;
 import com.harbortek.helm.system.vo.EnumItemVo;
@@ -24,9 +25,12 @@ import com.harbortek.helm.tracker.entity.block.*;
 import com.harbortek.helm.tracker.entity.smartdoc.element.parser.html2po.HtmlParser;
 import com.harbortek.helm.tracker.entity.smartdoc.element.parser.html2po.ParserRegister;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.SlateNode;
+import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.image.ImageHtmlParserConf;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.list.ListHtmlParserConf;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.list.ListSlateElement;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.paragraph.ParagraphHtmlParserConf;
+import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.table.TableHtmlParserConf;
+import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.table.TableSlateElement;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.text.SlateText;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.header.*;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.paragraph.ParagraphSlateElement;
@@ -40,6 +44,7 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Element;
 import org.jsoup.nodes.Node;
 import org.jsoup.nodes.TextNode;
+import org.jsoup.select.Elements;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -50,6 +55,8 @@ public class Block2Node {
         ParserRegister.registerParseStyleHtmlHandler(new DefaultParserStyleHtmlFn());
         ParserRegister.registerParseElemHtmlConf(new ParagraphHtmlParserConf());
         ParserRegister.registerParseElemHtmlConf(new ListHtmlParserConf());
+        ParserRegister.registerParseElemHtmlConf(new ImageHtmlParserConf());
+        ParserRegister.registerParseElemHtmlConf(new TableHtmlParserConf());
     }
 
     public static SlateNode parse(DocBlock docBlock) {
@@ -76,32 +83,76 @@ public class Block2Node {
                 paragraphSlateElement.getChildren().add(slateText);
                 return paragraphSlateElement;
             }
-            //ul,ol 特殊处理
-            if (all.get(0) instanceof Element && ((Element) all.get(0)).is("ul,ol")) {
-                Element firstChild = (Element) all.get(0);
-                ListSlateElement listSlateElement = new ListSlateElement<>();
-                for (Node node : firstChild.childNodes()) {
-                    Element element = wrapperText(node);
-                    SlateNode parseElemHtml = HtmlParser.parseElemHtml(element);
-                    children.add(parseElemHtml);
+            if (all.get(0) instanceof Element) {
+                //ul,ol 特殊处理
+                if (((Element) all.get(0)).is("ul,ol")) {
+                    Element firstChild = (Element) all.get(0);
+                    String tagName = firstChild.tagName();
+                    ParagraphSlateElement paragraphSlateElement = new ParagraphSlateElement();
+                    for (Node node : firstChild.childNodes()) {
+                        Element element = wrapperText(node);
+                        if (StringUtils.isEmpty(StringUtils.trimToEmpty(element.html()))) {
+                            continue;
+                        }
+                        SlateNode parseElemHtml = HtmlParser.parseElemHtml(element);
+                        ListSlateElement listSlateElement = new ListSlateElement<>();
+                        listSlateElement.setLevel(1L);
+                        listSlateElement.setOrdered(tagName.equals("ol"));
+                        listSlateElement.getChildren().add(parseElemHtml);
+                        children.add(listSlateElement);
+                    }
+                    paragraphSlateElement.setChildren(children);
+                    paragraphSlateElement.setId(docBlock.getId());
+                    return paragraphSlateElement;
                 }
-                listSlateElement.setOrdered(firstChild.tagName().equals("ol"));
-                listSlateElement.setChildren(children);
-                listSlateElement.setId(docBlock.getId());
-                return listSlateElement;
-            } else {
-                ParagraphSlateElement<SlateNode> paragraphSlateElement = new ParagraphSlateElement<>();
-                String html = HtmlUtil.removeHtmlTag(paragraphBlockData.getText(), "p");
-                for (Node node : Jsoup.parse(html).body().childNodes()) {
-                    Element element = wrapperText(node);
+                //table 特殊处理
+                if (((Element) all.get(0)).is("table,tbody")) {
+                    Element firstChild = (Element) all.get(0);
+                    final List<Element> trElements = new ArrayList<>();
+                    firstChild.getElementsByTag("tr").forEach(e -> trElements.add(e));
+                    TableSlateElement tableSlateElement = new TableSlateElement<>();
+                    for (Element tr : trElements) {
+                        boolean isHeader = tr.tagName().equals("th");
+                        TableSlateElement.TableRowSlateElement tableRowSlateElement = new TableSlateElement.TableRowSlateElement();
+                        List<Element> tdElements = new ArrayList<>();
+                        for (Element td : tr.getElementsByTag("td")) {
+                            tdElements.add(td);
+                        }
+                        for (Element td : tr.getElementsByTag("th")) {
+                            tdElements.add(td);
+                        }
+                        for (Element td : tdElements) {
+                            String colSpan = td.attr("colspan");
+                            String rowspan = td.attr("rowspan");
+                            TableSlateElement.TableCellSlateElement tableCellSlateElement = new TableSlateElement.TableCellSlateElement();
+                            tableCellSlateElement.setIsHeader(isHeader);
+                            if (NumberUtil.isNumber(colSpan)) {
+                                tableCellSlateElement.setColSpan(Integer.parseInt(colSpan));
 
-                    SlateNode parseElemHtml = HtmlParser.parseElemHtml(element);
-                    children.add(parseElemHtml);
+                            }
+                            if (NumberUtil.isNumber(rowspan)) {
+                                tableCellSlateElement.setRowSpan(Integer.parseInt(rowspan));
+                            }
+                            SlateNode childrenTd = HtmlParser.parseElemHtml(td);
+                            tableCellSlateElement.getChildren().add(childrenTd);
+                            tableRowSlateElement.getChildren().add(tableCellSlateElement);
+                        }
+                        tableSlateElement.getChildren().add(tableRowSlateElement);
+                    }
+                    tableSlateElement.setWidth("100%");
+                    return tableSlateElement;
                 }
-                paragraphSlateElement.setChildren(children);
-                paragraphSlateElement.setId(docBlock.getId());
-                return paragraphSlateElement;
             }
+            ParagraphSlateElement<SlateNode> paragraphSlateElement = new ParagraphSlateElement<>();
+            String html = HtmlUtil.removeHtmlTag(paragraphBlockData.getText(), "p");
+            for (Node node : Jsoup.parse(html).body().childNodes()) {
+                Element element = wrapperText(node);
+                SlateNode parseElemHtml = HtmlParser.parseElemHtml(element);
+                children.add(parseElemHtml);
+            }
+            paragraphSlateElement.setChildren(children);
+            paragraphSlateElement.setId(docBlock.getId());
+            return paragraphSlateElement;
         } else if (blockData instanceof TrackerItemBlockData) {
             TrackerItemBlockData trackerItemBlockData = (TrackerItemBlockData) blockData;
             TrackerItemSlateElement<SlateNode> trackerItemSlateElement = new TrackerItemSlateElement<>();
@@ -196,7 +247,7 @@ public class Block2Node {
     }
 
     private static TrackerItemVo fillTrackerItemVo(TrackerItemBlockData.InnerTrackerItemVo trackerItemVo) {
-        if(trackerItemVo == null){
+        if (trackerItemVo == null) {
             trackerItemVo = new TrackerItemBlockData.InnerTrackerItemVo();
         }
         TrackerItemVo trackerItemVo2 = new TrackerItemVo();
@@ -214,6 +265,7 @@ public class Block2Node {
         trackerItemVo2.setItemNo(trackerItemVo.getItemNo());
         trackerItemVo2.setAssignedDate(trackerItemVo.getAssignedDate());
 
+        trackerItemVo2.setPriority(EnumItemVo.builder().id(trackerItemVo.getPriorityId()).build());
         trackerItemVo2.setProgress(trackerItemVo.getProgress());
         trackerItemVo2.setCloseDate(trackerItemVo.getCloseDate());
         trackerItemVo2.setEstimateWorkingHours(trackerItemVo.getEstimateWorkingHours());

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/parser/block/DefaultParserStyleHtmlFn.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/parser/block/DefaultParserStyleHtmlFn.java
@@ -41,7 +41,7 @@ public class DefaultParserStyleHtmlFn implements ParseStyleHtmlFn {
         SlateText text = new SlateText();
         text.setText(((SlateText) textNode).getText());
         // bold
-        StyleedStyle style = StyleedStyle.builder().build();
+        StyleedStyle style = new StyleedStyle();
         boolean styleChanged = false;
         if (isMatch(elem, "b,strong")) {
             style.setBold(true);

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/parser/block/Node2Block.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/parser/block/Node2Block.java
@@ -27,6 +27,7 @@ import com.harbortek.helm.tracker.entity.smartdoc.element.po.SlateNode;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.header.*;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.list.ListSlateElement;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.paragraph.ParagraphSlateElement;
+import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.table.TableSlateElement;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.title.TitleSlateElement;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.trackerItem.TrackerItemSlateElement;
 import com.harbortek.helm.tracker.vo.ProjectVo;
@@ -64,7 +65,7 @@ public class Node2Block {
             docBlock = DocBlock.builder()
                     .type(BlockTypes.TITLE)
                     .data(TitleBlockData.builder().text(
-                            unwrapper(titleSlateElement.toHtml())
+                            unwrapper(titleSlateElement.html())
                     ).build())
                     .build();
         } else if (node instanceof HeaderSlateElement<?>) {
@@ -84,7 +85,7 @@ public class Node2Block {
             docBlock = DocBlock.builder()
                     .type(BlockTypes.HEADING)
                     .data(HeaderBlockData.builder().level(level).text(
-                                    unwrapper(headerSlateElement.toHtml()))
+                                    unwrapper(headerSlateElement.html()))
                             .build())
                     .build();
 
@@ -100,8 +101,8 @@ public class Node2Block {
                 type = trackerItemVo.getTracker().getId().toString();
             }
             List<SlateNode> children = trackerItemSlateElement.getChildren();
-            String name = HtmlUtil.cleanHtmlTag(children.get(0).toHtml());
-            String description = children.get(1).toHtml();
+            String name = HtmlUtil.cleanHtmlTag(children.get(0).html());
+            String description = children.get(1).html();
             Long trackerId = trackerItemVo.getTracker() != null ? trackerItemVo.getTracker().getId() : null;
             docBlock = DocBlock.builder()
                     .type(type)
@@ -114,13 +115,20 @@ public class Node2Block {
             docBlock = DocBlock.builder()
                     .type(BlockTypes.PARAGRAPH)
                     .data(ParagraphBlockData.builder().text(
-                            unwrapper((listSlateElement.toHtml()))).build())
+                            unwrapper((listSlateElement.html()))).build())
+                    .build();
+        } else if (node instanceof TableSlateElement<?>) {
+            TableSlateElement<?> tableSlateElement = (TableSlateElement<?>) node;
+            docBlock = DocBlock.builder()
+                    .type(BlockTypes.PARAGRAPH)
+                    .data(ParagraphBlockData.builder().text(
+                            (tableSlateElement.html())).build())
                     .build();
         } else {
             docBlock = DocBlock.builder()
                     .type(BlockTypes.PARAGRAPH)
                     .data(ParagraphBlockData.builder().text(
-                            unwrapper((node.toHtml()))).build())
+                            unwrapper((node.html()))).build())
                     .build();
         }
         docBlock.setId(node.getId());
@@ -173,6 +181,7 @@ public class Node2Block {
         Optional.ofNullable(trackerItemVo.getSeverity())
                 .ifPresent(value -> trackerItemVo2.setSeverityId(value.getId()));
 
+        trackerItemVo2.setPriorityId(trackerItemVo.getPriority().getId());
         trackerItemVo2.setProgress(trackerItemVo.getProgress());
         trackerItemVo2.setCloseDate(trackerItemVo.getCloseDate());
         trackerItemVo2.setEstimateWorkingHours(trackerItemVo.getEstimateWorkingHours());

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/parser/html2po/HtmlParser.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/parser/html2po/HtmlParser.java
@@ -48,7 +48,6 @@ public class HtmlParser {
                 return ParseTextElemHtml.parseTextElemHtml(elem);
             }
         }
-
         // Special handling for <code>
         if (tagName.equals("code")) {
             String parentTagName = ((Element) elem).parent().tagName().toLowerCase();

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/parser/html2po/ParseCommonElemHtml.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/parser/html2po/ParseCommonElemHtml.java
@@ -58,7 +58,7 @@ public class ParseCommonElemHtml {
     /**
      * Generate slate node children.
      *
-     * @param elem   DOM element
+     * @param elem DOM element
      * @return list of SlateNode
      */
     public static List<SlateNode> genChildren(Node elem) {
@@ -117,11 +117,34 @@ public class ParseCommonElemHtml {
      */
     private static SlateElement defaultParser(Element elem, List<SlateNode> children) {
         SlateText text = new SlateText(elem.text().replaceAll("\\s+", " "));
-        ParagraphSlateElement<SlateText> paragraph = new ParagraphSlateElement<SlateText>();
-        List<SlateText> childrenText = new ArrayList<>();
-        childrenText.add(text);
-        paragraph.setChildren(childrenText);
+        ParagraphSlateElement paragraph = new ParagraphSlateElement();
+//        List<SlateText> childrenText = new ArrayList<>();
+//        childrenText.add(text);
+//        paragraph.setChildren(childrenText);
+        List<SlateNode> newChildren = new ArrayList<>();
+        for (SlateNode slateNode : children) {
+            newChildren.addAll(unwrapperChildren(slateNode));
+        }
+        paragraph.setChildren(newChildren);
         return paragraph;
+    }
+
+    private static List<SlateNode> unwrapperChildren(SlateNode item) {
+        List<SlateNode> newChildren = new ArrayList<>();
+        if (item instanceof SlateText) {
+            newChildren.add(item);
+        } else {
+            SlateElement<SlateNode> childElement = (SlateElement) item;
+            List<SlateNode> childrenElement = childElement.getChildren();
+            if (childrenElement.isEmpty()) {
+                newChildren.add(item);
+            } else {
+                for (SlateNode slateNodeChild : childrenElement) {
+                    newChildren.addAll(unwrapperChildren(slateNodeChild));
+                }
+            }
+        }
+        return newChildren;
     }
 
     /**
@@ -147,7 +170,7 @@ public class ParseCommonElemHtml {
     /**
      * Process common DOM element HTML, non-text elements like span or font.
      *
-     * @param elem   DOM element
+     * @param elem DOM element
      * @return list of Element
      */
     public static SlateElement parseCommonElemHtml(Element elem) {
@@ -159,6 +182,10 @@ public class ParseCommonElemHtml {
             if (children.isEmpty()) {
                 element.setChildren(new ArrayList());
                 element.getChildren().add(new SlateText(elem.html().replaceAll("\\s+", " ")));
+            } else {
+                for (SlateNode child : children) {
+
+                }
             }
 
             // Process style

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/parser/html2po/ParseElemHtmlFn.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/parser/html2po/ParseElemHtmlFn.java
@@ -23,5 +23,5 @@ import org.jsoup.nodes.Element;
 import java.util.List;
 
 public interface ParseElemHtmlFn {
-        SlateElement apply(Element elem, List<SlateNode> children);
-    }
+    SlateElement apply(Element elem, List<SlateNode> children);
+}

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/PoUtils.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/PoUtils.java
@@ -1,5 +1,15 @@
 package com.harbortek.helm.tracker.entity.smartdoc.element.po;
 
+import cn.hutool.core.bean.BeanUtil;
+import cn.hutool.core.bean.copier.CopyOptions;
+import cn.hutool.json.JSONArray;
+import cn.hutool.json.JSONObject;
+import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.SlateElement;
+import com.harbortek.helm.tracker.entity.smartdoc.element.po.style.SlateStyle;
+import com.harbortek.helm.tracker.entity.smartdoc.element.po.style.StyleedStyle;
+
+import java.util.List;
+
 public class PoUtils {
     public static boolean isPlainText(String text) {
         // 移除所有空白字符
@@ -18,5 +28,55 @@ public class PoUtils {
 
         // 使用正则表达式检查是否包含HTML标签
         return !text.matches(".*<[^>]+>.*");
+    }
+
+    public static JSONArray toMap(List<SlateNode> nodes) {
+        JSONArray roots = new JSONArray();
+        for (SlateNode node : nodes) {
+            JSONObject root = new JSONObject();
+            BeanUtil.copyProperties(node, root, CopyOptions.create().ignoreNullValue());
+            List<StyleedStyle> styles = node.getStyles();
+            if ((styles != null && !styles.isEmpty())) {
+                for (Object styleObj : styles) {
+                    BeanUtil.copyProperties(styleObj, root, CopyOptions.create().ignoreNullValue());
+                }
+                node.setStyles(null);
+            }
+            if (node instanceof SlateElement<?>) {
+                SlateElement element = (SlateElement) node;
+                JSONArray childrenMap = new JSONArray();
+                List<SlateNode> children = element.getChildren();
+                if (children != null && !children.isEmpty()) {
+                    childrenMap = toMap(children);
+                    root.put("children", childrenMap);
+                }
+            }
+            roots.add(root);
+        }
+        return roots;
+    }
+
+    public static JSONArray toMap(JSONArray nodes) {
+        JSONArray roots = new JSONArray();
+        for (Object obj : nodes) {
+            JSONObject node = (JSONObject) obj;
+            JSONObject root = new JSONObject();
+            BeanUtil.copyProperties(node, root, CopyOptions.create().ignoreNullValue());
+            JSONArray styles = node.getJSONArray("styles");
+            if ((styles != null && !styles.isEmpty())) {
+                for (Object styleObj : styles) {
+                    BeanUtil.copyProperties(styleObj, root, CopyOptions.create().ignoreNullValue());
+                }
+                node.put("styles", null);
+            }
+            JSONArray childrenMap = new JSONArray();
+            JSONArray children = node.getJSONArray("children");
+            if (children != null && !children.isEmpty()) {
+                childrenMap = toMap(children);
+                root.put("children", childrenMap);
+            }
+            roots.add(root);
+        }
+        return roots;
     }
 }

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/SlateNode.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/SlateNode.java
@@ -20,6 +20,7 @@ import cn.hutool.core.lang.id.NanoId;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.style.SlateStyle;
+import com.harbortek.helm.tracker.entity.smartdoc.element.po.style.StyleedStyle;
 import com.harbortek.helm.util.IDUtils;
 import lombok.Data;
 import org.apache.commons.lang3.StringUtils;
@@ -34,19 +35,20 @@ import java.util.List;
         include = JsonTypeInfo.As.PROPERTY,
         property = "type"
 )
-@Data
 public abstract class SlateNode implements Serializable {
     protected String type;
 
     private String id;
-    protected List<SlateStyle> styles = new ArrayList();
+    protected List<StyleedStyle> styles = null;
 
     abstract public String toHtml();
 
     public String html() {
         String html = toHtml();
-        for (SlateStyle style : styles) {
-            html = style.styleToHtml(this, html);
+        if (styles != null) {
+            for (SlateStyle style : styles) {
+                html = style.styleToHtml(this, html);
+            }
         }
         return html;
     }
@@ -64,5 +66,21 @@ public abstract class SlateNode implements Serializable {
             this.id = IDUtils.getShortId();
         }
         return id;
+    }
+
+    public List<StyleedStyle> getStyles() {
+        return styles;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setStyles(List<StyleedStyle> styles) {
+        this.styles = styles;
     }
 }

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/AttachmentSlateElement.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/AttachmentSlateElement.java
@@ -24,7 +24,10 @@ import lombok.Data;
 @Data
 @JsonTypeName(SlateElements.ATTACHMENT)
 public class AttachmentSlateElement<SlateText> extends SlateElement {
-    private String type = SlateElements.ATTACHMENT;
+    public AttachmentSlateElement() {
+        super();
+        this.type = SlateElements.ATTACHMENT;
+    }
 
     private String fileName;
 

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/BlockQuoteSlateElement.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/BlockQuoteSlateElement.java
@@ -24,7 +24,11 @@ import lombok.Data;
 @Data
 @JsonTypeName(SlateElements.BLOCKQUOTE)
 public class BlockQuoteSlateElement<StateText> extends SlateElement {
-    private String type = SlateElements.BLOCKQUOTE;
+
+    public BlockQuoteSlateElement() {
+        super();
+        type = SlateElements.BLOCKQUOTE;
+    }
 
     @Override
     public String toHtml() {

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/CodeSlateElement.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/CodeSlateElement.java
@@ -24,9 +24,12 @@ import lombok.Data;
 @Data
 @JsonTypeName(SlateElements.CODE)
 public class CodeSlateElement<PureSlateText> extends SlateElement {
-    private String type = SlateElements.CODE;
     private String language;
 
+    public CodeSlateElement() {
+        super();
+        type = SlateElements.CODE;
+    }
 
     @Override
     public String toHtml() {

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/DividerSlateElement.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/DividerSlateElement.java
@@ -23,8 +23,11 @@ import lombok.Data;
 @Data
 @JsonTypeName(SlateElements.DIVIDER)
 public class DividerSlateElement<EmptySlateText> extends SlateElement {
-    private String type =  SlateElements.DIVIDER;
 
+    public DividerSlateElement() {
+        super();
+        type = SlateElements.DIVIDER;
+    }
     @Override
     public String toHtml() {
         return "<hr/>";

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/LinkSlateElement.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/LinkSlateElement.java
@@ -25,7 +25,12 @@ import lombok.Data;
 @Data
 @JsonTypeName(SlateElements.LINK)
 public class LinkSlateElement<SlateText> extends SlateElement {
-    private String type = SlateElements.LINK;
+
+    public LinkSlateElement() {
+        super();
+        type = SlateElements.LINK;
+    }
+
     @NotEmpty
     private String url;
     private String target;

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/PreSlateElement.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/PreSlateElement.java
@@ -24,7 +24,11 @@ import lombok.Data;
 @Data
 @JsonTypeName(SlateElements.PRE)
 public class PreSlateElement<CodeSlateElement> extends SlateElement {
-    private String type = SlateElements.PRE;
+
+    public PreSlateElement() {
+        super();
+        type = SlateElements.PRE;
+    }
 
     @Override
     public String toHtml() {

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/SlateElement.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/SlateElement.java
@@ -19,8 +19,8 @@ package com.harbortek.helm.tracker.entity.smartdoc.element.po.element;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.SlateNode;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.style.SlateStyle;
+import org.springframework.data.annotation.Transient;
 
-import java.beans.Transient;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,6 +28,9 @@ public abstract class SlateElement<T extends SlateNode> extends SlateNode {
     protected String type;
     private List<T> children = new ArrayList<>();
 
+    public SlateElement() {
+        super();
+    }
 
     public List<T> getChildren() {
         return children;
@@ -45,23 +48,14 @@ public abstract class SlateElement<T extends SlateNode> extends SlateNode {
         return type;
     }
 
-    protected List<SlateStyle> styles = new ArrayList<>();
-
-    public List<SlateStyle> getStyles() {
-        return styles;
-    }
-
-    public void setStyles(List<SlateStyle> styles) {
-        this.styles = styles;
-    }
-
     @JsonIgnore
+    @Transient
     private String childrenHtml;
 
     public String getChildrenHtml() {
         StringBuilder sb = new StringBuilder();
         for (SlateNode child : children) {
-            sb.append(child.toHtml());
+            sb.append(child.html());
         }
         return sb.toString();
     }

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/TodoSlateElement.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/TodoSlateElement.java
@@ -25,7 +25,12 @@ import lombok.Data;
 @Data
 @JsonTypeName(SlateElements.TODO)
 public class TodoSlateElement<SlateText> extends SlateElement {
-    private String type = SlateElements.TODO;
+
+    public TodoSlateElement() {
+        super();
+        type = SlateElements.TODO;
+    }
+
     @NotEmpty
     private Boolean checked = false;
 

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/header/Header1SlateElement.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/header/Header1SlateElement.java
@@ -24,8 +24,11 @@ import lombok.Data;
 @Data
 @JsonTypeName(SlateElements.HEADER1)
 public class Header1SlateElement<SlateText> extends HeaderSlateElement {
-    private String type = SlateElements.HEADER1;
 
+    public Header1SlateElement() {
+        super();
+        type = SlateElements.HEADER1;
+    }
     @Override
     public String toHtml() {
         return StrUtil.format("""

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/header/Header2SlateElement.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/header/Header2SlateElement.java
@@ -24,7 +24,12 @@ import lombok.Data;
 @Data
 @JsonTypeName(SlateElements.HEADER2)
 public class Header2SlateElement<SlateText> extends HeaderSlateElement {
-    private String type =  SlateElements.HEADER2;
+
+    public Header2SlateElement() {
+        super();
+        type = SlateElements.HEADER2;
+    }
+
     @Override
     public String toHtml() {
         return StrUtil.format("""

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/header/Header3SlateElement.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/header/Header3SlateElement.java
@@ -24,7 +24,10 @@ import lombok.Data;
 @Data
 @JsonTypeName(SlateElements.HEADER3)
 public class Header3SlateElement<SlateText> extends HeaderSlateElement {
-    private String type =  SlateElements.HEADER3;
+    public Header3SlateElement() {
+        super();
+        type = SlateElements.HEADER3;
+    }
 
     @Override
     public String toHtml() {

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/header/Header4SlateElement.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/header/Header4SlateElement.java
@@ -24,7 +24,11 @@ import lombok.Data;
 @Data
 @JsonTypeName(SlateElements.HEADER4)
 public class Header4SlateElement<SlateText> extends HeaderSlateElement {
-    private String type =  SlateElements.HEADER4;
+
+    public Header4SlateElement() {
+        super();
+        type = SlateElements.HEADER4;
+    }
 
     @Override
     public String toHtml() {

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/header/Header5SlateElement.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/header/Header5SlateElement.java
@@ -24,8 +24,11 @@ import lombok.Data;
 @Data
 @JsonTypeName(SlateElements.HEADER5)
 public class Header5SlateElement<SlateText> extends HeaderSlateElement {
-    private String type =  SlateElements.HEADER5;
 
+    public Header5SlateElement() {
+        super();
+        type = SlateElements.HEADER5;
+    }
 
     @Override
     public String toHtml() {

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/image/ImageHtmlParserConf.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/image/ImageHtmlParserConf.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright [2025] [Harbortek Corp.]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harbortek.helm.tracker.entity.smartdoc.element.po.element.image;
+
+import com.harbortek.helm.tracker.entity.smartdoc.element.parser.html2po.ParseElemHtmlConf;
+import com.harbortek.helm.tracker.entity.smartdoc.element.parser.html2po.ParseElemHtmlFn;
+import com.harbortek.helm.tracker.entity.smartdoc.element.po.SlateNode;
+import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.SlateElement;
+import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.list.ListSlateElement;
+import com.harbortek.helm.tracker.entity.smartdoc.element.po.text.SlateText;
+import org.jsoup.nodes.Element;
+
+import java.awt.*;
+import java.util.List;
+
+public class ImageHtmlParserConf extends ParseElemHtmlConf {
+    private static final String SELECTOR = "img";
+
+    public ImageHtmlParserConf() {
+        super(SELECTOR, new ImagetHtmlParserFn());
+    }
+
+    private static class ImagetHtmlParserFn implements ParseElemHtmlFn {
+
+        @Override
+        public SlateElement apply(Element elem, List<SlateNode> children) {
+
+            ImageSlateElement imageSlateElement = new ImageSlateElement();
+            String tagName = elem.tagName();
+            String alt = elem.attr("alt");
+            String src = elem.attr("src");
+            String href = elem.attr("href");
+
+            imageSlateElement.setAlt(alt);
+            imageSlateElement.setSrc(src);
+            imageSlateElement.setHref(href);
+            ImageSlateElement.ImageStyle is = new ImageSlateElement.ImageStyle();
+            imageSlateElement.setStyle(is);
+            // 无 children ，则用纯文本
+            if (children.size() == 0) {
+                children.add(new SlateText(elem.text()));
+            } else {
+                imageSlateElement.setChildren(children);
+            }
+            return imageSlateElement;
+        }
+
+    }
+
+
+}

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/image/ImageSlateElement.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/image/ImageSlateElement.java
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package com.harbortek.helm.tracker.entity.smartdoc.element.po.element;
+package com.harbortek.helm.tracker.entity.smartdoc.element.po.element.image;
 
 import cn.hutool.core.util.StrUtil;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.SlateElements;
+import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.SlateElement;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Data;
 
@@ -27,7 +28,12 @@ import java.io.Serializable;
 @Data
 @JsonTypeName(SlateElements.IMAGE)
 public class ImageSlateElement<EmptySlateText> extends SlateElement {
-    private String type = SlateElements.IMAGE;
+
+    public ImageSlateElement() {
+        super();
+        type = SlateElements.IMAGE;
+    }
+
     @NotEmpty
     private String src;
     private String alt;
@@ -35,20 +41,23 @@ public class ImageSlateElement<EmptySlateText> extends SlateElement {
     private ImageStyle style;
 
     @Data
-    public class ImageStyle implements Serializable {
+    public static class ImageStyle implements Serializable {
         private String width;
         private String height;
 
         public String toHtml() {
             return StrUtil.format("""
-                    width:{width};
-                    height:{height};
+                    width:{};
+                    height:{};
                     """, width, height);
         }
     }
 
     @Override
     public String toHtml() {
+        if (style == null) {
+            style = new ImageStyle();
+        }
         return StrUtil.format("""
                 <img src="{}" alt="{}" data-href="{}" style="{}"/>
                 """, src, alt, href, style.toHtml());

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/list/ListSlateElement.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/list/ListSlateElement.java
@@ -27,10 +27,14 @@ import org.apache.commons.lang3.StringUtils;
 @Data
 @JsonTypeName(SlateElements.LIST)
 public class ListSlateElement<T extends SlateNode> extends SlateElement {
-    private String type = SlateElements.LIST;
+
+    public ListSlateElement() {
+        super();
+        type = SlateElements.LIST;
+    }
 
     private Boolean ordered; // 有序/无序
-    private Long level; // 层级：0 1 2 ...
+    private Long level = 1L; // 层级：0 1 2 ...
 
     @Override
     public String toHtml() {

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/paragraph/ParagraphSlateElement.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/paragraph/ParagraphSlateElement.java
@@ -27,7 +27,11 @@ import org.apache.commons.lang3.StringUtils;
 @Data
 @JsonTypeName(SlateElements.PARAGRAPH)
 public class ParagraphSlateElement<T extends SlateNode> extends SlateElement {
-    private String type = SlateElements.PARAGRAPH;
+
+    public ParagraphSlateElement() {
+        super();
+        type = SlateElements.PARAGRAPH;
+    }
 
     @Override
     public String toHtml() {

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/table/TableHtmlParserConf.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/table/TableHtmlParserConf.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright [2025] [Harbortek Corp.]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.harbortek.helm.tracker.entity.smartdoc.element.po.element.table;
+
+import cn.hutool.core.util.NumberUtil;
+import com.harbortek.helm.tracker.entity.smartdoc.element.parser.html2po.HtmlParser;
+import com.harbortek.helm.tracker.entity.smartdoc.element.parser.html2po.ParseElemHtmlConf;
+import com.harbortek.helm.tracker.entity.smartdoc.element.parser.html2po.ParseElemHtmlFn;
+import com.harbortek.helm.tracker.entity.smartdoc.element.po.SlateNode;
+import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.SlateElement;
+import com.harbortek.helm.tracker.entity.smartdoc.element.po.element.list.ListSlateElement;
+import com.harbortek.helm.tracker.entity.smartdoc.element.po.text.SlateText;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class TableHtmlParserConf extends ParseElemHtmlConf {
+    private static final String SELECTOR = "table";
+
+    public TableHtmlParserConf() {
+        super(SELECTOR, new TableHtmlParserFn());
+    }
+
+    private static class TableHtmlParserFn implements ParseElemHtmlFn {
+
+        @Override
+        public SlateElement apply(Element elem, List<SlateNode> children) {
+            final List<Element> trElements = new ArrayList<>();
+            elem.getElementsByTag("tr").forEach(e -> trElements.add(e));
+            TableSlateElement tableSlateElement = new TableSlateElement<>();
+            for (Element tr : trElements) {
+                boolean isHeader = tr.tagName().equals("th");
+                TableSlateElement.TableRowSlateElement tableRowSlateElement = new TableSlateElement.TableRowSlateElement();
+                List<Element> tdElements = new ArrayList<>();
+                for (Element td : tr.getElementsByTag("td")) {
+                    tdElements.add(td);
+                }
+                for (Element td : tr.getElementsByTag("th")) {
+                    tdElements.add(td);
+                }
+                for (Element td : tdElements) {
+                    String colSpan = td.attr("colspan");
+                    String rowspan = td.attr("rowspan");
+                    TableSlateElement.TableCellSlateElement tableCellSlateElement = new TableSlateElement.TableCellSlateElement();
+                    if (NumberUtil.isNumber(colSpan)) {
+                        tableCellSlateElement.setColSpan(Integer.parseInt(colSpan));
+                    }
+                    if (NumberUtil.isNumber(rowspan)) {
+                        tableCellSlateElement.setRowSpan(Integer.parseInt(rowspan));
+                    }
+                    tableCellSlateElement.setIsHeader(isHeader);
+                    tableCellSlateElement.getChildren().add(HtmlParser.parseElemHtml(td));
+                    tableRowSlateElement.getChildren().add(tableCellSlateElement);
+                }
+                tableSlateElement.getChildren().add(tableRowSlateElement);
+            }
+            tableSlateElement.setWidth("100%");
+            return tableSlateElement;
+        }
+
+    }
+
+
+}

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/table/TableSlateElement.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/table/TableSlateElement.java
@@ -25,8 +25,12 @@ import lombok.Data;
 @Data
 @JsonTypeName(SlateElements.TABLE)
 public class TableSlateElement<TableRowSlateElement> extends SlateElement {
-    private String type = SlateElements.TABLE;
     private String width = "auto";
+
+    public TableSlateElement() {
+        super();
+        type = SlateElements.TABLE;
+    }
 
     @Override
     public String toHtml() {

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/title/TitleSlateElement.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/title/TitleSlateElement.java
@@ -25,7 +25,10 @@ import lombok.Data;
 @Data
 @JsonTypeName(SlateElements.TITLE)
 public class TitleSlateElement<SlateText> extends SlateElement {
-    private String type = SlateElements.TITLE;
+    public TitleSlateElement() {
+        super();
+        type = SlateElements.TITLE;
+    }
 
     @Override
     public String toHtml() {

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/trackerItem/TrackerItemSlateElement.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/element/trackerItem/TrackerItemSlateElement.java
@@ -27,7 +27,12 @@ import org.springframework.data.annotation.Transient;
 @Data
 @JsonTypeName(SlateElements.TRACKER_ITEM)
 public class TrackerItemSlateElement<SlateText> extends SlateElement {
-    private String type = SlateElements.TRACKER_ITEM;
+
+    public TrackerItemSlateElement() {
+        super();
+        type = SlateElements.TRACKER_ITEM;
+    }
+
     private String ref;
     @Transient
     private TrackerItemVo trackerItem;
@@ -35,8 +40,8 @@ public class TrackerItemSlateElement<SlateText> extends SlateElement {
     @Override
     public String toHtml() {
         return StrUtil.format("""
-                    <p data-x-ref={}>{}</p>
-                    """, ref, getChildrenHtml());
+                <p data-x-ref={}>{}</p>
+                """, ref, getChildrenHtml());
     }
 
     @Data

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/style/SlateStyle.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/style/SlateStyle.java
@@ -2,8 +2,13 @@ package com.harbortek.helm.tracker.entity.smartdoc.element.po.style;
 
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.SlateNode;
 
-public abstract class SlateStyle {
+import java.io.Serializable;
 
+public abstract class SlateStyle implements Serializable {
+    protected String type;
+
+    public SlateStyle() {
+    }
 
     public abstract String styleToHtml(SlateNode node, String html);
 }

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/style/StyleedStyle.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/style/StyleedStyle.java
@@ -28,7 +28,6 @@ import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 
 @Data
-@Builder
 @JsonTypeName(SlateElements.StyleSlateText)
 public class StyleedStyle extends SlateStyle {
 
@@ -39,6 +38,18 @@ public class StyleedStyle extends SlateStyle {
     private Boolean through;
     private Boolean sub;
     private Boolean sup;
+
+    public StyleedStyle() {
+        this.type = SlateElements.StyleSlateText;
+
+        this.bold = false;
+        this.code = false;
+        this.italic = false;
+        this.underline = false;
+        this.through = false;
+        this.sub = false;
+        this.sup = false;
+    }
 
     public String styleToHtml(SlateNode textNode, String html) {
         if (!(textNode instanceof SlateText)) {

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/text/SlateText.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/po/text/SlateText.java
@@ -43,15 +43,6 @@ public class SlateText extends SlateNode {
     public SlateText() {
     }
 
-    protected List<SlateStyle> styles = new ArrayList<>();
-
-    public List<SlateStyle> getStyles() {
-        return styles;
-    }
-
-    public void setStyles(List<SlateStyle> styles) {
-        this.styles = styles;
-    }
     @Override
     public String toHtml() {
         return this.text;

--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/vo/block/DocVo.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/vo/block/DocVo.java
@@ -16,6 +16,10 @@
 
 package com.harbortek.helm.tracker.vo.block;
 
+import cn.hutool.json.JSONArray;
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.harbortek.helm.common.vo.BaseVo;
 import com.harbortek.helm.tracker.entity.block.DocBlock;
 import com.harbortek.helm.tracker.entity.smartdoc.element.po.SlateNode;
@@ -24,6 +28,8 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldNameConstants;
 import lombok.experimental.SuperBuilder;
+import org.json.JSONPropertyName;
+import org.springframework.data.annotation.Transient;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -35,9 +41,15 @@ import java.util.List;
 @FieldNameConstants
 public class DocVo extends BaseVo {
 
-//    private Long pageId;
+    //    private Long pageId;
     private Long version;
     private List<DocBlock> blocks = new ArrayList<>();
+    @JsonIgnore
     private List<SlateNode> elements = new ArrayList<>();
+
+    //前台格式转换用，不做存储，实际使用elements
+    @JsonProperty("elements")
+    @Transient
+    private JSONArray rawElements = new JSONArray();
 
 }


### PR DESCRIPTION
- 新增 TableSlateElement 类用于解析表格
- 优化 ParagraphSlateElement 类,支持递归解析子元素
- 重构 Block2Node 类,支持 ul/ol 和 table元素的解析
- 更新相关类的构造方法,初始化 type属性
- 优化 DocVo 类,添加 rawElements 字段用于存储原始元素数据
- 改进 PoUtils 类,增加 toMap 方法用于转换元素列表为 JSON 数组