### PR TITLE
fix(tracker): 修复智能文档中 tracker 项描述为空时的解析问题

### DIFF
--- a/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/parser/block/Block2Node.java
+++ b/server/helm-tracker/src/main/java/com/harbortek/helm/tracker/entity/smartdoc/element/parser/block/Block2Node.java
@@ -175,21 +175,12 @@ public class Block2Node {
             trackerItemDescriptionSlateElement.setChildren(subChildren);
             trackerItemDescriptionSlateElement.setRef(refId);
 
-            Element container = new Element("span");
-            String txt = StringUtils.isEmpty(trackerItemBlockData.getText()) ? "" : trackerItemBlockData.getText();
+            String txt = StringUtils.isEmpty(trackerItemBlockData.getText()) ? "<p><span></span></p>" : trackerItemBlockData.getText();
             for (Node node : Jsoup.parse(txt).body().childNodes()) {
                 Element element = wrapperText(node);
-                container.appendChild(element);
+                SlateNode parseElemHtml = HtmlParser.parseElemHtml(element);
+                subChildren.add(parseElemHtml);
             }
-            SlateNode parseElemHtml = HtmlParser.parseElemHtml(container);
-//            if (parseElemHtml instanceof SlateText) {
-//                ParagraphSlateElement pItem = new ParagraphSlateElement<>();
-//                pItem.getChildren().add(parseElemHtml);
-//                subChildren.add(pItem);
-//            } else {
-//                subChildren.add(parseElemHtml);
-//            }
-            subChildren.add(parseElemHtml);
             trackerItemSlateElement.setChildren(children);
 
 

--- a/web/src/components/smart-doc/SmartDoc.vue
+++ b/web/src/components/smart-doc/SmartDoc.vue
@@ -331,6 +331,7 @@ export default {
       const that = this;
       this.docLoading = true;
       this.converters = [];
+      this.doc.isReady = false;
       if (that.pageId) {
         Promise.all([this.initCurrentPage(), this.initEditorJSBlocks(), this.initTrackers()])
           .then(([page, newDoc, trackers]) => {
@@ -345,7 +346,7 @@ export default {
             setTimeout(() => {
               console.log(`doc is ready!`);
               this.doc.isReady = true;
-            }, 0);
+            }, 200);
             trackerItemApi.set(this.doc.id, trackerItems);
 
             const { version, blocks, lastModifiedDate } = newDoc;


### PR DESCRIPTION
- 修改了 Block2Node 类中的解析逻辑，当 tracker 项描述为空时，生成一个空的 <p> 标签
- 优化了解析流程，移除了不必要的代码和注释- 在 SmartDoc 组件中添加了 isReady 标志，并在文档加载完成后设置为 true
- 调整了文档加载完成后的延时设置，提高用户体验